### PR TITLE
feat: add `preset` alias for `extends`

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ export function createLogger(
 
 ### Extras
 #### Presets
-Introduce your own reusable presets via `extends`. This statement can be applied at any [config](#config) level and should return a valid value for the current section. The specified path will be loaded synchronously through `require`, so it must be a JSON or CJS module.
+Introduce your own reusable snippets via `extends` or `preset`. This statement can be applied at any [config](#config) level and should return a valid value for the current section. The specified path will be loaded synchronously through `require`, so it must be a JSON or CJS module.
 ```js
 const config = {
   // should return `firewall` and `servers`

--- a/src/main/js/config.js
+++ b/src/main/js/config.js
@@ -9,7 +9,7 @@ const populateExtra = (raw) => typeof raw === 'string' ? require(raw) : {}
 
 const populate = (config) => {
   const profiles = asArray(config).map(_p => {
-    const p = {...populateExtra(_p.extends), ..._p}
+    const p = {...populateExtra(_p.extends || _p.preset), ..._p}
 
     assert.ok(p.server, 'cfg: server')
     assert.ok(p.firewall, 'cfg: firewall')
@@ -24,9 +24,10 @@ const populate = (config) => {
       keepAliveTimeout = 61_000,
       headersTimeout = 62_000,
       requestTimeout = 30_000,
-      extends: _extends
+      preset,
+      extends: _extends,
     }) => {
-      const extra = populateExtra(_extends)
+      const extra = populateExtra(_extends || preset)
       const secure = _secure
         ? {
           key: fs.readFileSync(_secure.key, 'utf8'),
@@ -52,7 +53,7 @@ const populate = (config) => {
     const firewall = asArray(p.firewall).map(f => {
       assert.ok(f.registry, 'cfg: firewall.registry')
 
-      const extra = populateExtra(f?.extends)
+      const extra = populateExtra(f.extends || f.preset)
       const rules = [...asArray(f.rules || []), ...asArray(extra.rules || [])].map((_raw) => {
         const {
           policy,
@@ -65,7 +66,7 @@ const populate = (config) => {
           username,
           filter,
           plugin
-        } = {...populateExtra(_raw.extends), ..._raw}
+        } = {...populateExtra(_raw.extends || _raw.preset), ..._raw}
         assert.ok(policy || plugin, 'cfg: firewall.rules.policy or firewall.rules.plugin')
         version && assert.ok(semver.validRange(version), 'cfg: firewall.rules.version semver')
 

--- a/src/test/js/config.js
+++ b/src/test/js/config.js
@@ -3,7 +3,7 @@ import {getConfig} from '../../main/js/config.js'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const test = testFactory('config', import.meta)
 
@@ -33,6 +33,27 @@ test('resolves `extends`', () => {
     firewall: {
       registry: 'https://registry.npmjs.org',
       rules: [{policy: 'deny', extends: resolve(__dirname, '../fixtures/custom-plugin.cjs')}]
+    }
+  }])
+  objectContaining(config, {
+    profiles: [{
+      firewall: [{
+        base: '/',
+        rules: [{
+          age: [5],
+          policy: 'deny',
+        }]
+      }]
+    }]
+  })
+})
+
+test('resolves `preset`', () => {
+  const config = getConfig([{
+    server: {port: 3000},
+    firewall: {
+      registry: 'https://registry.npmjs.org',
+      rules: [{policy: 'deny', preset: resolve(__dirname, '../fixtures/custom-plugin.cjs')}]
     }
   }])
   objectContaining(config, {


### PR DESCRIPTION
closes #22

## Changes
```js
{
   extends: 'some-file'
}
// equals
{
   preset: 'some-file'
}
```

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
