### PR TITLE
feat: support several target registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ type TCacheFactory = {
 }
 
 type TFirewallConfig = {
-  registry: string
+  registry: string | string[]
   entrypoint?: string
   token?: string
   base?: string

--- a/src/main/js/config.js
+++ b/src/main/js/config.js
@@ -90,7 +90,7 @@ const populate = (config) => {
 
       return {
         rules,
-        registry: normalizePath(f.registry),
+        registry: f.registry ? asArray(f.registry).map(normalizePath) : null,
         token: f.token,
         entrypoint: f.entrypoint ? normalizePath(f.entrypoint) : null,
         base: f.base || '/',

--- a/src/main/js/firewall/plugins/audit.js
+++ b/src/main/js/firewall/plugins/audit.js
@@ -1,7 +1,7 @@
 import {semver} from '../../semver.js'
 import {request} from '../../http/index.js'
 import {getCache} from '../../cache.js'
-import {makeDeferred} from '../../util.js'
+import {asArray, makeDeferred, tryQueue} from '../../util.js'
 
 const severityOrder = ['critical', 'high', 'moderate', 'low', 'any' ]
 
@@ -16,6 +16,13 @@ export const auditPlugin = async ({entry: {name, version}, options = {}, boundCo
 }
 
 const getAdvisories = async (name, registry) => {
+  const registries = asArray(registry || registry)
+  const args = registries.map(r => [name, r])
+
+  return tryQueue(_getAdvisories, ...args)
+}
+
+const _getAdvisories = async (name, registry) => {
   const cache = getCache({ name: 'audit', ttl: 120_000 })
   if (await cache.has(name)) {
     return cache.get(name)

--- a/src/main/js/index.d.ts
+++ b/src/main/js/index.d.ts
@@ -68,7 +68,7 @@ type TCacheFactory = {
 }
 
 type TFirewallConfig = {
-  registry: string
+  registry: string | string[]
   entrypoint?: string
   token?: string
   base?: string

--- a/src/main/js/mwares/proxy.js
+++ b/src/main/js/mwares/proxy.js
@@ -1,6 +1,14 @@
 import {request} from '../http/client.js'
+import {asArray, tryQueue} from '../util.js'
 
 export const proxy = (registry) => async (req, res) => {
-  const url = `${registry}${req.url}`
-  await request({ url, method: req.method, pipe: {req, res}, followRedirects: true})
+  const registries = asArray(registry)
+  const args = registries.map(r => [{
+    url: `${r}${req.url}`,
+    method: req.method,
+    pipe: {req, res},
+    followRedirects: true
+  }])
+
+  return tryQueue(request, ...args)
 }

--- a/src/main/js/util.js
+++ b/src/main/js/util.js
@@ -123,3 +123,15 @@ export const mergeDeep = (target, ...sources) => {
 
   return mergeDeep(target, ...sources)
 }
+
+export const tryQueue = async (fn, ...args) => {
+  const results = await Promise.allSettled(args.map(a => fn(...a)))
+  const success = results.find(r => r.status === 'fulfilled')
+
+  if (success) {
+    return success.value
+  }
+
+  const error = results.find(r => r.status === 'rejected')
+  return Promise.reject(error.reason)
+}

--- a/src/test/js/app.js
+++ b/src/test/js/app.js
@@ -23,7 +23,7 @@ const app = createApp([{
 }, {
   server: { port: 3003 },
   firewall: {
-    registry: 'https://registry.yarnpkg.com',
+    registry: ['https://registry.yarnpkg.com', 'https://registry.npmjs.org'],
     rules: { policy: 'deny', name: '*' }
   }
 }])

--- a/src/test/js/util.js
+++ b/src/test/js/util.js
@@ -1,5 +1,5 @@
 import {testFactory, assert} from '../test-utils.js'
-import {flatten, expand} from '../../main/js/util.js'
+import {flatten, expand, tryQueue} from '../../main/js/util.js'
 
 const test = testFactory('util', import.meta)
 
@@ -26,4 +26,19 @@ test('expand', () => {
     foo: 'bar',
     baz: [{a: 'a'}, {b: {c: 'd'}}, 1]
   })
+})
+
+test('tryQueue', async() => {
+  const fn = async (i) => {
+    if (i === 0) { throw new Error('broken') }
+    return i
+  }
+
+  assert.equal(await tryQueue(fn, [0], [0], [3]), 3)
+
+  try {
+    await tryQueue(fn, [0])
+  } catch (err) {
+    assert.equal(err.message, 'broken')
+  }
 })


### PR DESCRIPTION
closes #62

## Changes
<!-- What exactly you have changed, and how it works now -->
```js
{
  server: { port: 3003 },
  firewall: {
    registry: ['https://registry.yarnpkg.com', 'https://registry.npmjs.org'],
    rules: { policy: 'deny', name: '*' }
  }
}
```

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
